### PR TITLE
feat: Add Developer Info Maven Plugin and display goal

### DIFF
--- a/EmptyProject/pom.xml
+++ b/EmptyProject/pom.xml
@@ -13,23 +13,33 @@
             <id>evgeny228</id>
             <name>Evgeny the Great</name>
             <email>evegeny.great@mail.astondevs.ru</email>
-            <organization>Aston Education</organization>
             <url>https://astondevs.ru/</url>
+            <organization>Aston Education</organization>
+            <organizationUrl>https://astondevs.ru/</organizationUrl>
             <roles>
                 <role>Swing Software Engineer</role>
                 <role>TeachLead Developer</role>
             </roles>
             <timezone>+1</timezone>
+            <properties>
+                <twitter>evgeny_twitter</twitter>
+                <github>evgeny_github</github>
+            </properties>
         </developer>
         <developer>
             <id>AlexeyGoodGuy</id>
             <name>Alexey Kuznetsov</name>
             <email>alex.kuzntetsov@mail.astondevs.ru</email>
-            <organization>Aston Education</organization>
             <url>https://astondevs.ru/</url>
+            <organization>Aston Education</organization>
+            <organizationUrl>https://astondevs.ru/</organizationUrl>
             <roles>
                 <role>QA Engineer</role>
             </roles>
+            <timezone>UTC+3</timezone>
+            <properties>
+                <linkedin>alexey_linkedin</linkedin>
+            </properties>
         </developer>
     </developers>
 

--- a/EmptyProject/pom.xml
+++ b/EmptyProject/pom.xml
@@ -8,10 +8,54 @@
     <artifactId>EmptyProject</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <developers>
+        <developer>
+            <id>evgeny228</id>
+            <name>Evgeny the Great</name>
+            <email>evegeny.great@mail.astondevs.ru</email>
+            <organization>Aston Education</organization>
+            <url>https://astondevs.ru/</url>
+            <roles>
+                <role>Swing Software Engineer</role>
+                <role>TeachLead Developer</role>
+            </roles>
+            <timezone>+1</timezone>
+        </developer>
+        <developer>
+            <id>AlexeyGoodGuy</id>
+            <name>Alexey Kuznetsov</name>
+            <email>alex.kuzntetsov@mail.astondevs.ru</email>
+            <organization>Aston Education</organization>
+            <url>https://astondevs.ru/</url>
+            <roles>
+                <role>QA Engineer</role>
+            </roles>
+        </developer>
+    </developers>
+
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.plugin</groupId>
+                <artifactId>MavenPlugin</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <executions>
+                    <execution>
+                        <id>display-dev-info</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>display</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/MavenPlugin/pom.xml
+++ b/MavenPlugin/pom.xml
@@ -7,11 +7,71 @@
     <groupId>org.plugin</groupId>
     <artifactId>MavenPlugin</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+
+    <name>Developer Info Maven Plugin</name>
+    <description>A Maven plugin to display developer information from pom.xml</description>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.version>3.8.6</maven.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>17</java.version>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${maven.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.6.1</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.6.1</version>
+                <configuration>
+                    <goalPrefix>devinfo</goalPrefix>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-descriptor</id>
+                        <goals>
+                            <goal>descriptor</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                    </execution>
+                    <execution>
+                        <id>help-descriptor</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/MavenPlugin/pom.xml
+++ b/MavenPlugin/pom.xml
@@ -14,6 +14,8 @@
 
     <properties>
         <maven.version>3.8.6</maven.version>
+        <maven.tools.version>3.6.1</maven.tools.version>
+        <commons-collections4.version>4.4</commons-collections4.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
     </properties>
@@ -32,8 +34,13 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.6.1</version>
+            <version>${maven.tools.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>${commons-collections4.version}</version>
         </dependency>
     </dependencies>
 

--- a/MavenPlugin/src/main/java/org/plugin/Main.java
+++ b/MavenPlugin/src/main/java/org/plugin/Main.java
@@ -1,7 +1,0 @@
-package org.example;
-
-public class Main {
-    public static void main(String[] args) {
-        System.out.println("Hello world!");
-    }
-}

--- a/MavenPlugin/src/main/java/org/plugin/devinfo/DeveloperInfoMojo.java
+++ b/MavenPlugin/src/main/java/org/plugin/devinfo/DeveloperInfoMojo.java
@@ -1,0 +1,93 @@
+package org.plugin.devinfo;
+
+import org.apache.maven.model.*;
+import org.apache.maven.plugin.*;
+import org.apache.maven.plugins.annotations.*;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.project.*;
+
+import java.util.*;
+import java.util.stream.*;
+
+/**
+ * Maven plugin to display developer information from the project's pom.xml.
+ */
+@Mojo(name = "display", defaultPhase = LifecyclePhase.VALIDATE)
+public class DeveloperInfoMojo extends AbstractMojo {
+
+    /**
+     * The Maven Project object.
+     * Injected by Maven itself.
+     */
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
+    private MavenProject project;
+
+
+    /**
+     * Main logic of the plugin.
+     */
+    @Override
+    public void execute() {
+        getLog().info("------------------------------------------------------------------------");
+        getLog().info("                  DEVELOPER INFORMATION PLUGIN                          ");
+        getLog().info("------------------------------------------------------------------------");
+
+        List<Developer> developers = project.getDevelopers();
+
+        if (isValid(developers)) return;
+
+        getLog().info("Found " + developers.size() + " developer(s):");
+        getLog().info("");
+
+        showDevelopers(developers);
+
+        getLog().info("------------------------------------------------------------------------");
+        getLog().info("                  PLUGIN EXECUTION COMPLETE                             ");
+        getLog().info("------------------------------------------------------------------------");
+    }
+
+    /**
+     * Shows developer information if the list is valid.
+     */
+    private boolean isValid(List<Developer> developers) {
+        if (developers == null || developers.isEmpty()) {
+            getLog().warn("No developer information found in pom.xml for project: " + project.getArtifactId());
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Displays developer information.
+     */
+    private void showDevelopers(List<Developer> developers) {
+        int developerCount = 1;
+        for (Developer developer : developers) {
+            getLog().info("--- Developer " + developerCount++ + " ---");
+            getLog().info("ID:          " + (developer.getId() != null ? developer.getId() : "N/A"));
+            getLog().info("Name:        " + (developer.getName() != null ? developer.getName() : "N/A"));
+            getLog().info("Email:       " + (developer.getEmail() != null ? developer.getEmail() : "N/A"));
+            getLog().info("Organization: " + (developer.getOrganization() != null ? developer.getOrganization() : "N/A"));
+            getLog().info("URL:         " + (developer.getUrl() != null ? developer.getUrl() : "N/A"));
+            getLog().info("Timezone:    " + (developer.getTimezone() != null ? developer.getTimezone() : "N/A"));
+
+            showRoles(developer);
+            getLog().info("");
+        }
+    }
+
+    /**
+     * Displays developer roles.
+     */
+    private void showRoles(Developer developer) {
+        if (developer.getRoles() != null && !developer.getRoles().isEmpty()) {
+            String roles = developer.getRoles().stream()
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.joining(", "));
+            getLog().info("Roles:       " + roles);
+        } else {
+            getLog().info("Roles:       N/A");
+        }
+    }
+}

--- a/MavenPlugin/src/main/java/org/plugin/devinfo/DeveloperInfoMojo.java
+++ b/MavenPlugin/src/main/java/org/plugin/devinfo/DeveloperInfoMojo.java
@@ -1,5 +1,6 @@
 package org.plugin.devinfo;
 
+import org.apache.commons.collections4.*;
 import org.apache.maven.model.*;
 import org.apache.maven.plugin.*;
 import org.apache.maven.plugins.annotations.*;
@@ -61,17 +62,24 @@ public class DeveloperInfoMojo extends AbstractMojo {
      * Displays developer information.
      */
     private void showDevelopers(List<Developer> developers) {
+        if (developers == null || developers.isEmpty()) {
+            getLog().info("No developers information available");
+            return;
+        }
+
         int developerCount = 1;
         for (Developer developer : developers) {
             getLog().info("--- Developer " + developerCount++ + " ---");
-            getLog().info("ID:          " + (developer.getId() != null ? developer.getId() : "N/A"));
-            getLog().info("Name:        " + (developer.getName() != null ? developer.getName() : "N/A"));
-            getLog().info("Email:       " + (developer.getEmail() != null ? developer.getEmail() : "N/A"));
-            getLog().info("Organization: " + (developer.getOrganization() != null ? developer.getOrganization() : "N/A"));
-            getLog().info("URL:         " + (developer.getUrl() != null ? developer.getUrl() : "N/A"));
-            getLog().info("Timezone:    " + (developer.getTimezone() != null ? developer.getTimezone() : "N/A"));
+            getLog().info("ID:          " + Optional.ofNullable(developer.getId()).orElse("N/A"));
+            getLog().info("Name:        " + Optional.ofNullable(developer.getName()).orElse("N/A"));
+            getLog().info("Email:       " + Optional.ofNullable(developer.getEmail()).orElse("N/A"));
+            getLog().info("URL:         " + Optional.ofNullable(developer.getUrl()).orElse("N/A"));
+            getLog().info("Organization: " + Optional.ofNullable(developer.getOrganization()).orElse("N/A"));
+            getLog().info("Org URL:     " + Optional.ofNullable(developer.getOrganizationUrl()).orElse("N/A"));
+            getLog().info("Timezone:    " + Optional.ofNullable(developer.getTimezone()).orElse("N/A"));
 
             showRoles(developer);
+            showProperties(developer);
             getLog().info("");
         }
     }
@@ -80,14 +88,25 @@ public class DeveloperInfoMojo extends AbstractMojo {
      * Displays developer roles.
      */
     private void showRoles(Developer developer) {
-        if (developer.getRoles() != null && !developer.getRoles().isEmpty()) {
+        if (CollectionUtils.isNotEmpty(developer.getRoles())) {
             String roles = developer.getRoles().stream()
                     .map(String::trim)
-                    .filter(s -> !s.isEmpty())
+                    .filter(role -> !role.isEmpty())
                     .collect(Collectors.joining(", "));
             getLog().info("Roles:       " + roles);
         } else {
             getLog().info("Roles:       N/A");
+        }
+    }
+
+    private void showProperties(Developer developer) {
+        if (MapUtils.isNotEmpty(developer.getProperties())) {
+            String props = developer.getProperties().entrySet().stream()
+                    .map(entry -> entry.getKey() + ": " + entry.getValue())
+                    .collect(Collectors.joining(", "));
+            getLog().info("Properties:   " + props);
+        } else {
+            getLog().info("Properties:   N/A");
         }
     }
 }


### PR DESCRIPTION
Нужно реализовать maven plugin, который будет выводить информцию о разработчике\разработчиках. Информация об этом находится в теге <developers> [https://maven.apache.org/pom.html#Developers](https://maven.apache.org/pom.html#Developers).

Проект MavenPlugin должен содержать сам плагин. После реализации плагина, его нужно поключить к проекту EmptyProject.

Выполнение:

1. Добавление тестовых разработчиков в <developers>
2. Сохранение в mavenLocal
3. Импорт в EmptyProject